### PR TITLE
Allow for the ETL to use schema names other than "omop".

### DIFF
--- a/README-run-etl.md
+++ b/README-run-etl.md
@@ -16,7 +16,8 @@ To simplify the reusability of these scripts, we define a few environment variab
 First is the connection string used to connect to the database. Note this also specifies the schema using `search_path`.
 
 ```bash
-export OMOP='host=localhost dbname=postgres user=postgres options=--search_path=omop'
+export OMOP_SCHEMA='omop'
+export OMOP='host=localhost dbname=postgres user=postgres options=--search_path='$OMOP_SCHEMA
 export MIMIC='host=localhost dbname=postgres user=postgres options=--search_path=mimiciii'
 # or, e.g., export OMOP="dbname=mimic options=--search_path=omop"
 ```
@@ -63,7 +64,7 @@ This will load various manual mappings to the database under the `mimiciii` sche
 Be sure to run this from the *root* folder of the repository, or the relative path names will cause errors.
 
 ```sh
-psql "$MIMIC" -f "etl/etl.sql"
+psql "$MIMIC" --set=OMOP_SCHEMA="$OMOP_SCHEMA" -f "etl/etl.sql"
 ```
 
 ## 5. Check the ETL has run properly

--- a/etl/StandardizedClinicalDataTables/CONDITION_OCCURRENCE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/CONDITION_OCCURRENCE/etl.sql
@@ -1,6 +1,6 @@
 WITH
 "gcpt_seq_num_to_concept" as (SELECT seq_num, concept_id as condition_type_concept_id FROM gcpt_seq_num_to_concept),
-"icd9_concept" as ( SELECT concept_id, concept_code FROM omop.concept WHERE vocabulary_id = 'ICD9CM'),
+"icd9_concept" as ( SELECT concept_id, concept_code FROM :OMOP_SCHEMA.concept WHERE vocabulary_id = 'ICD9CM'),
 "diag" as (
 SELECT
     mimic_id as condition_occurrence_id
@@ -20,10 +20,10 @@ WHERE icd9_code IS NOT NULL
 "snomed_map" as (
    SELECT rel.concept_id_1
         , min(rel.concept_id_2) AS condition_concept_id
-     FROM omop.concept_relationship as rel
-     JOIN omop.concept as c1
+     FROM :OMOP_SCHEMA.concept_relationship as rel
+     JOIN :OMOP_SCHEMA.concept as c1
        ON (concept_id_1       = c1.concept_id)
-     JOIN omop.concept as c2
+     JOIN :OMOP_SCHEMA.concept as c2
        ON (concept_id_2       = c2.concept_id)
     WHERE rel.relationship_id = 'Maps to'
       AND c1.vocabulary_id    = 'ICD9CM'
@@ -79,7 +79,7 @@ SELECT
 FROM admissions
 LEFT JOIN patients ON (subject_id = hadm_subject_id)
 LEFT JOIN adm_diag_cpt USING (diagnosis))
-INSERT INTO omop.condition_occurrence
+INSERT INTO :OMOP_SCHEMA.condition_occurrence
 (
     condition_occurrence_id
   , person_id

--- a/etl/StandardizedClinicalDataTables/DEATH/etl.sql
+++ b/etl/StandardizedClinicalDataTables/DEATH/etl.sql
@@ -8,7 +8,7 @@ WITH
 	SELECT mimic_id as person_id, dod_ssn as death_datetime, 261 as death_type_concept_id
 	FROM patients LEFT JOIN death_adm ON (mimic_id = person_id)
 	WHERE dod_ssn IS NOT NULL AND death_adm.person_id IS NULL)
- INSERT INTO omop.DEATH
+ INSERT INTO :OMOP_SCHEMA.DEATH
  (
 	 person_id, death_date, death_datetime, death_type_concept_id
  )

--- a/etl/StandardizedClinicalDataTables/DRUG_EXPOSURE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/DRUG_EXPOSURE/etl.sql
@@ -25,7 +25,7 @@ WITH
 ),
 "patients" AS (SELECT subject_id, mimic_id as person_id from patients),
 "admissions" AS (SELECT hadm_id, mimic_id as visit_occurrence_id FROM admissions),
-":OMOP_SCHEMA_local_drug" AS (SELECT concept_name as drug_source_value, concept_id as drug_source_concept_id FROM :OMOP_SCHEMA.concept WHERE domain_id = 'prescriptions' AND vocabulary_id = 'MIMIC prescriptions'),
+"omop_local_drug" AS (SELECT concept_name as drug_source_value, concept_id as drug_source_concept_id FROM :OMOP_SCHEMA.concept WHERE domain_id = 'prescriptions' AND vocabulary_id = 'MIMIC prescriptions'),
 "row_to_insert" AS (
 	SELECT
   drug_exposure_id
@@ -53,7 +53,7 @@ WITH
 , dose_unit_source_value
 , form_val_disp as quantity_source_value
 FROM pr
-LEFT JOIN :OMOP_SCHEMA_local_drug USING (drug_source_value)
+LEFT JOIN omop_local_drug USING (drug_source_value)
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 )

--- a/etl/StandardizedClinicalDataTables/MEASUREMENT/etl.sql
+++ b/etl/StandardizedClinicalDataTables/MEASUREMENT/etl.sql
@@ -18,14 +18,14 @@ WITH
 "admissions" AS (SELECT mimic_id AS visit_occurrence_id, hadm_id FROM admissions),
 "d_labitems" AS (SELECT itemid, label as measurement_source_value, fluid, loinc_code, category, mimic_id FROM d_labitems),
 "gcpt_lab_label_to_concept" AS (SELECT label as measurement_source_value, concept_id as measurement_concept_id FROM gcpt_lab_label_to_concept),
-"omop_loinc" AS (SELECT concept_id AS measurement_concept_id, concept_code as loinc_code FROM omop.concept WHERE vocabulary_id = 'LOINC' AND domain_id = 'Measurement'),
-"omop_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM omop.concept WHERE  domain_id ilike 'Meas Value Operator'),
+":OMOP_SCHEMA_loinc" AS (SELECT concept_id AS measurement_concept_id, concept_code as loinc_code FROM :OMOP_SCHEMA.concept WHERE vocabulary_id = 'LOINC' AND domain_id = 'Measurement'),
+":OMOP_SCHEMA_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM :OMOP_SCHEMA.concept WHERE  domain_id ilike 'Meas Value Operator'),
 "gcpt_lab_unit_to_concept" AS (SELECT unit as unit_source_value, concept_id as unit_concept_id FROM gcpt_lab_unit_to_concept),
 "row_to_insert" AS (
 SELECT
   labevents.measurement_id
 , patients.person_id
-, coalesce(omop_loinc.measurement_concept_id, gcpt_lab_label_to_concept.measurement_concept_id, 0) as measurement_concept_id
+, coalesce(:OMOP_SCHEMA_loinc.measurement_concept_id, gcpt_lab_label_to_concept.measurement_concept_id, 0) as measurement_concept_id
 , labevents.measurement_datetime::date AS measurement_date
 , labevents.measurement_datetime AS measurement_datetime
 , CASE
@@ -52,8 +52,8 @@ FROM labevents
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 LEFT JOIN d_labitems USING (itemid)
-LEFT JOIN omop_loinc USING (loinc_code)
-LEFT JOIN omop_operator USING (operator_name)
+LEFT JOIN :OMOP_SCHEMA_loinc USING (loinc_code)
+LEFT JOIN :OMOP_SCHEMA_operator USING (operator_name)
 LEFT JOIN gcpt_lab_label_to_concept USING (measurement_source_value)
 LEFT JOIN gcpt_lab_unit_to_concept USING (unit_source_value)
 LEFT JOIN gcpt_labs_specimen_to_concept ON (d_labitems.fluid =  gcpt_labs_specimen_to_concept.label)
@@ -79,7 +79,7 @@ SELECT
 FROM row_to_insert
 ),
 "insert_specimen_lab" AS (
-INSERT INTO omop.specimen
+INSERT INTO :OMOP_SCHEMA.specimen
 (
 	  specimen_id
 	, person_id
@@ -117,7 +117,7 @@ FROM specimen_lab
 RETURNING *
 ),
 "insert_fact_relationship_specimen_measurement" AS (
-    INSERT INTO omop.fact_relationship
+    INSERT INTO :OMOP_SCHEMA.fact_relationship
     (SELECT
       36 AS domain_concept_id_1 -- Specimen
     , specimen_id as fact_id_1
@@ -135,7 +135,7 @@ RETURNING *
     FROM specimen_lab
     )
 )
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -194,7 +194,7 @@ WITH
 	, extract_value_period_decimal(value)    as value_as_number
 	, coalesce(valueuom, extract_unit(value)) AS unit_source_value
 	FROM chartevents
-        JOIN omop.concept -- concept driven dispatcher
+        JOIN :OMOP_SCHEMA.concept -- concept driven dispatcher
         ON (    concept_code  = itemid::Text
             AND domain_id     = 'Measurement'
             AND vocabulary_id = 'MIMIC d_items'
@@ -206,10 +206,10 @@ WITH
 "d_items" AS (SELECT itemid, category, label, mimic_id FROM d_items),
 "patients" AS (SELECT mimic_id AS person_id, subject_id FROM patients),
 "admissions" AS (SELECT mimic_id AS visit_occurrence_id, hadm_id FROM admissions),
-"omop_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM omop.concept WHERE  domain_id ilike 'Meas Value Operator'),
-"omop_loinc" AS (
+":OMOP_SCHEMA_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM :OMOP_SCHEMA.concept WHERE  domain_id ilike 'Meas Value Operator'),
+":OMOP_SCHEMA_loinc" AS (
 	SELECT distinct on (concept_name) concept_id AS measurement_concept_id, concept_name as label
-	FROM omop.concept
+	FROM :OMOP_SCHEMA.concept
 	WHERE vocabulary_id = 'LOINC'
 	AND domain_id = 'Measurement'
 	AND standard_concept = 'S'),
@@ -220,7 +220,7 @@ WITH
 	SELECT
   chartevents_lab.measurement_id
 , patients.person_id
-, coalesce(omop_loinc.measurement_concept_id, gcpt_lab_label_to_concept.measurement_concept_id, 0) as measurement_concept_id
+, coalesce(:OMOP_SCHEMA_loinc.measurement_concept_id, gcpt_lab_label_to_concept.measurement_concept_id, 0) as measurement_concept_id
 , chartevents_lab.measurement_datetime::date AS measurement_date
 , chartevents_lab.measurement_datetime AS measurement_datetime
 , CASE
@@ -248,8 +248,8 @@ WITH
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 LEFT JOIN d_items USING (itemid)
-LEFT JOIN omop_loinc USING (label)
-LEFT JOIN omop_operator USING (operator_name)
+LEFT JOIN :OMOP_SCHEMA_loinc USING (label)
+LEFT JOIN :OMOP_SCHEMA_operator USING (operator_name)
 LEFT JOIN gcpt_lab_label_to_concept USING (label)
 LEFT JOIN gcpt_labs_from_chartevents_to_concept USING (category, label)
 LEFT JOIN gcpt_lab_unit_to_concept USING (unit_source_value)
@@ -275,7 +275,7 @@ SELECT
 FROM row_to_insert
 ),
 "insert_specimen_lab" AS (
-INSERT INTO omop.specimen
+INSERT INTO :OMOP_SCHEMA.specimen
 (
 	  specimen_id
 	, person_id
@@ -313,7 +313,7 @@ FROM specimen_lab
 RETURNING *
 ),
 "insert_fact_relationship_specimen_measurement" AS (
-    INSERT INTO omop.fact_relationship
+    INSERT INTO :OMOP_SCHEMA.fact_relationship
     (SELECT
       36 AS domain_concept_id_1 -- Specimen
     , specimen_id as fact_id_1
@@ -331,7 +331,7 @@ RETURNING *
     FROM specimen_lab
     )
 )
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -428,7 +428,7 @@ WITH
 		AND coalesce(resistance.org_name,'') = coalesce(culture.org_name,''))
 ),
 "insert_fact_relationship" AS (
-    INSERT INTO omop.fact_relationship
+    INSERT INTO :OMOP_SCHEMA.fact_relationship
     (SELECT
       21 AS domain_concept_id_1 -- Measurement
     , fact_id_1
@@ -470,7 +470,7 @@ FROM culture
 LEFT JOIN patients USING (subject_id)
 ),
 "insert_specimen_culture" AS (
-INSERT INTO omop.specimen
+INSERT INTO :OMOP_SCHEMA.specimen
 (
 	  specimen_id
 	, person_id
@@ -508,7 +508,7 @@ FROM specimen_culture
 RETURNING *
 ),
 "insert_fact_relationship_specimen_measurement" AS (
-    INSERT INTO omop.fact_relationship
+    INSERT INTO :OMOP_SCHEMA.fact_relationship
     (SELECT
       36 AS domain_concept_id_1 -- Specimen
     , specimen_id as fact_id_1
@@ -526,11 +526,11 @@ RETURNING *
     FROM specimen_culture
     )
 ),
-"omop_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM omop.concept WHERE  domain_id ilike 'Meas Value Operator'),
+":OMOP_SCHEMA_operator" AS (SELECT concept_name as operator_name, concept_id as operator_concept_id FROM :OMOP_SCHEMA.concept WHERE  domain_id ilike 'Meas Value Operator'),
 "gcpt_resistance_to_concept" AS (SELECT * FROM gcpt_resistance_to_concept),
-"gcpt_org_name_to_concept" AS (SELECT org_name, concept_id AS value_as_concept_id FROM gcpt_org_name_to_concept JOIN omop.concept ON (concept_code = snomed::text AND vocabulary_id = 'SNOMED')),
-"gcpt_spec_type_to_concept" AS (SELECT concept_id as measurement_concept_id, spec_type_desc as measurement_source_value FROM gcpt_spec_type_to_concept LEFT JOIN omop.concept ON (loinc = concept_code AND standard_concept ='S' AND domain_id = 'Measurement')),
-"gcpt_atb_to_concept" AS (SELECT concept_id as measurement_concept_id, ab_name as measurement_source_value FROM gcpt_atb_to_concept LEFT JOIN omop.concept ON (concept.concept_code = gcpt_atb_to_concept.concept_code AND standard_concept = 'S' AND domain_id = 'Measurement')),
+"gcpt_org_name_to_concept" AS (SELECT org_name, concept_id AS value_as_concept_id FROM gcpt_org_name_to_concept JOIN :OMOP_SCHEMA.concept ON (concept_code = snomed::text AND vocabulary_id = 'SNOMED')),
+"gcpt_spec_type_to_concept" AS (SELECT concept_id as measurement_concept_id, spec_type_desc as measurement_source_value FROM gcpt_spec_type_to_concept LEFT JOIN :OMOP_SCHEMA.concept ON (loinc = concept_code AND standard_concept ='S' AND domain_id = 'Measurement')),
+"gcpt_atb_to_concept" AS (SELECT concept_id as measurement_concept_id, ab_name as measurement_source_value FROM gcpt_atb_to_concept LEFT JOIN :OMOP_SCHEMA.concept ON (concept.concept_code = gcpt_atb_to_concept.concept_code AND standard_concept = 'S' AND domain_id = 'Measurement')),
 "d_items" AS (SELECT mimic_id as measurement_source_concept_id, itemid FROM d_items WHERE category IN ( 'SPECIMEN', 'ORGANISM')),
 "row_to_insert" AS (SELECT
   culture.measurement_id AS measurement_id
@@ -585,9 +585,9 @@ LEFT JOIN gcpt_resistance_to_concept USING (interpretation)
 LEFT JOIN gcpt_atb_to_concept USING (measurement_source_value)
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
-LEFT JOIN omop_operator USING (operator_name)
+LEFT JOIN :OMOP_SCHEMA_operator USING (operator_name)
 )
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -698,7 +698,7 @@ SELECT
       m.value_ub as value_ub,
       concept.concept_code AS measurement_source_value
     FROM chartevents as c
-    JOIN omop.concept -- concept driven dispatcher
+    JOIN :OMOP_SCHEMA.concept -- concept driven dispatcher
     ON (    concept_code  = c.itemid::Text
 	AND domain_id     = 'Measurement'
 	AND vocabulary_id = 'MIMIC d_items'
@@ -747,7 +747,7 @@ FROM chartevents
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN caregivers USING (cgid)
 LEFT JOIN admissions USING (hadm_id))
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -790,7 +790,7 @@ SELECT
 , row_to_insert.unit_source_value
 , row_to_insert.value_source_value
 FROM row_to_insert
-LEFT JOIN omop.visit_detail_assign
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign
 ON row_to_insert.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail
@@ -852,7 +852,7 @@ LEFT JOIN d_items USING (itemid)
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN caregivers USING (cgid)
 LEFT JOIN admissions USING (hadm_id))
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -895,7 +895,7 @@ SELECT
 , row_to_insert.unit_source_value
 , row_to_insert.value_source_value
 FROM row_to_insert
-LEFT JOIN omop.visit_detail_assign
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign
 ON row_to_insert.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail
@@ -942,7 +942,7 @@ select
         LEFT JOIN admissions USING (hadm_id)
 	WHERE patientweight is not null
 )
-INSERT INTO omop.measurement
+INSERT INTO :OMOP_SCHEMA.measurement
 (
 	  measurement_id
 	, person_id
@@ -985,7 +985,7 @@ SELECT
 , row_to_insert.unit_source_value
 , row_to_insert.value_source_value
 FROM row_to_insert
-LEFT JOIN omop.visit_detail_assign
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign
 ON row_to_insert.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail

--- a/etl/StandardizedClinicalDataTables/NOTE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/NOTE/etl.sql
@@ -40,7 +40,7 @@ LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 LEFT JOIN caregivers USING (cgid)
 )
-INSERT INTO omop.NOTE
+INSERT INTO :OMOP_SCHEMA.NOTE
 (
     note_id
   , person_id

--- a/etl/StandardizedClinicalDataTables/OBSERVATION/etl.sql
+++ b/etl/StandardizedClinicalDataTables/OBSERVATION/etl.sql
@@ -255,7 +255,7 @@ FROM drgcodes
 SELECT
           observation_id
         , person_id
-        , 4296248 as observation_concept_id -- Cost containment drgcode should be in cost table apparently.... http://forums.ohdsi.org/t/most-appropriate-:OMOP_SCHEMA-table-to-house-drg-information/1591/9
+        , 4296248 as observation_concept_id -- Cost containment drgcode should be in cost table apparently.... http://forums.ohdsi.org/t/most-appropriate-omop-table-to-house-drg-information/1591/9
         , observation_datetime::date as observation_date
         , observation_datetime
         , 38000280 as observation_type_concept_id -- Observation recorded from EHR

--- a/etl/StandardizedClinicalDataTables/OBSERVATION/etl.sql
+++ b/etl/StandardizedClinicalDataTables/OBSERVATION/etl.sql
@@ -31,7 +31,7 @@
  LEFT JOIN caregivers USING (cgid)
  LEFT JOIN d_items USING (itemid)
 )
-INSERT INTO omop.OBSERVATION
+INSERT INTO :OMOP_SCHEMA.OBSERVATION
 (
     observation_id
   , person_id
@@ -72,7 +72,7 @@ SELECT
 , unit_source_value
 , qualifier_source_value
 FROM row_to_insert
-LEFT JOIN omop.visit_detail_assign
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign
 ON row_to_insert.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail
@@ -215,7 +215,7 @@ UNION ALL
     JOIN gcpt_ethnicity_to_concept as map USING (ethnicity)
     LEFT JOIN patients USING (subject_id)
   WHERE adm.ethnicity IS NOT NULL)
- INSERT INTO omop.OBSERVATION
+ INSERT INTO :OMOP_SCHEMA.OBSERVATION
 SELECT
           observation_id
         , person_id
@@ -255,7 +255,7 @@ FROM drgcodes
 SELECT
           observation_id
         , person_id
-        , 4296248 as observation_concept_id -- Cost containment drgcode should be in cost table apparently.... http://forums.ohdsi.org/t/most-appropriate-omop-table-to-house-drg-information/1591/9
+        , 4296248 as observation_concept_id -- Cost containment drgcode should be in cost table apparently.... http://forums.ohdsi.org/t/most-appropriate-:OMOP_SCHEMA-table-to-house-drg-information/1591/9
         , observation_datetime::date as observation_date
         , observation_datetime
         , 38000280 as observation_type_concept_id -- Observation recorded from EHR
@@ -276,7 +276,7 @@ SELECT
 	LEFT JOIN admissions USING (hadm_id)
 	LEFT JOIN gcpt_drgcode_to_concept USING (description)
 )
-INSERT INTO omop.observation
+INSERT INTO :OMOP_SCHEMA.observation
 SELECT
           observation_id
         , person_id
@@ -313,7 +313,7 @@ WITH
              , concept.concept_id as observation_source_concept_id
              , concept.concept_code as observation_source_value
           FROM chartevents
-	  JOIN omop.concept ON  -- concept driven dispatcher
+	  JOIN :OMOP_SCHEMA.concept ON  -- concept driven dispatcher
 		(           concept_code  = itemid::Text
 			AND domain_id     = 'Observation'
 			AND vocabulary_id = 'MIMIC d_items'
@@ -347,7 +347,7 @@ SELECT
         LEFT JOIN patients USING (subject_id)
         LEFT JOIN caregivers USING (cgid)
         LEFT JOIN admissions USING (hadm_id))
-INSERT INTO omop.observation
+INSERT INTO :OMOP_SCHEMA.observation
 SELECT
           observation_id
         , person_id
@@ -368,7 +368,7 @@ SELECT
         , unit_source_value
         , qualifier_source_value
 FROM row_to_insert
-LEFT JOIN omop.visit_detail_assign
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign
 ON row_to_insert.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail

--- a/etl/StandardizedClinicalDataTables/OBSERVATION_PERIOD/etl.sql
+++ b/etl/StandardizedClinicalDataTables/OBSERVATION_PERIOD/etl.sql
@@ -12,9 +12,9 @@ SELECT
 , visit_end_date as observation_period_end_date
 , visit_end_datetime as observation_period_end_datetime
 , 44814724  as period_type_concept_id  --  Period covering healthcare encounters
-FROM omop.visit_occurrence
+FROM :OMOP_SCHEMA.visit_occurrence
 )
-INSERT INTO omop.observation_period
+INSERT INTO :OMOP_SCHEMA.observation_period
 (
     observation_period_id
   , person_id

--- a/etl/StandardizedClinicalDataTables/PERSON/etl.sql
+++ b/etl/StandardizedClinicalDataTables/PERSON/etl.sql
@@ -2,7 +2,7 @@ WITH
 "patients" AS (SELECT subject_id, mimic_id as person_id, CASE WHEN gender ='F' THEN 8532 WHEN GENDER = 'M' THEN 8507 ELSE NULL END as gender_concept_id, extract(year FROM dob) as year_of_birth, extract(month FROM dob) as month_of_birth, extract(day FROM dob) as day_of_birth, dob as birth_datetime, gender as gender_source_value FROM patients),
 "gcpt_ethnicity_to_concept" AS (SELECT ethnicity, race_concept_id as race_concept_id, ethnicity_concept_id as ethnicity_concept_id FROM gcpt_ethnicity_to_concept),
 "admissions" AS (SELECT DISTINCT ON (subject_id) subject_id, first_value(ethnicity) OVER(PARTITION BY subject_id ORDER BY admittime ASC) as race_source_value FROM admissions)
- INSERT INTO omop.PERSON
+ INSERT INTO :OMOP_SCHEMA.PERSON
  (
      person_id
    , gender_concept_id

--- a/etl/StandardizedClinicalDataTables/PROCEDURE_OCCURRENCE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/PROCEDURE_OCCURRENCE/etl.sql
@@ -21,7 +21,7 @@ WITH
 ),
 "gcpt_procedure_to_concept" as (SELECT item_id as itemid, concept_id as procedure_concept_id from gcpt_procedure_to_concept),
 "cpt_event" AS ( SELECT mimic_id as procedure_occurrence_id , subject_id , hadm_id , chartdate as procedure_datetime, cpt_cd, subsectionheader as procedure_source_value FROM cptevents),
-":OMOP_SCHEMA_cpt4" as (SELECT concept_id as procedure_source_concept_id, concept_code as cpt_cd FROM :OMOP_SCHEMA.concept where vocabulary_id = 'CPT4'),
+"omop_cpt4" as (SELECT concept_id as procedure_source_concept_id, concept_code as cpt_cd FROM :OMOP_SCHEMA.concept where vocabulary_id = 'CPT4'),
 "standard_cpt4" as (
 	select distinct on (c1.concept_id) first_value(c2.concept_id) over(partition by c1.concept_id order by relationship_id ASC) as procedure_concept_id, c1.concept_code as cpt_cd --keep snomed in predilection
 	from :OMOP_SCHEMA.concept c1
@@ -45,12 +45,12 @@ SELECT
 , admissions.visit_occurrence_id
 , null::integer as visit_detail_id -- the chartdate is never a time, when exist
 , cpt_event.procedure_source_value
-, :OMOP_SCHEMA_cpt4.procedure_source_concept_id as procedure_source_concept_id
+, omop_cpt4.procedure_source_concept_id as procedure_source_concept_id
 , null::text as modifier_source_value
 FROM cpt_event
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
-LEFT JOIN :OMOP_SCHEMA_cpt4 USING (cpt_cd)
+LEFT JOIN omop_cpt4 USING (cpt_cd)
 LEFT JOIN standard_cpt4 USING (cpt_cd)
 UNION ALL
 SELECT

--- a/etl/StandardizedClinicalDataTables/PROCEDURE_OCCURRENCE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/PROCEDURE_OCCURRENCE/etl.sql
@@ -1,7 +1,7 @@
 WITH
 "proc_icd" as (SELECT mimic_id as procedure_occurrence_id, subject_id, hadm_id, icd9_code as procedure_source_value, CASE WHEN length(cast(ICD9_CODE as text)) = 2 THEN cast(ICD9_CODE as text) ELSE concat(substr(cast(ICD9_CODE as text), 1, 2), '.', substr(cast(ICD9_CODE as text), 3)) END AS concept_code FROM procedures_icd),
-"local_proc_icd" AS (SELECT concept_id as procedure_source_concept_id, concept_code as procedure_source_value FROM omop.concept WHERE domain_id = 'd_icd_procedures' AND vocabulary_id = 'MIMIC Local Codes'),
-"concept_proc_icd9" as ( SELECT concept_id as procedure_concept_id, concept_code FROM omop.concept WHERE vocabulary_id = 'ICD9Proc'),
+"local_proc_icd" AS (SELECT concept_id as procedure_source_concept_id, concept_code as procedure_source_value FROM :OMOP_SCHEMA.concept WHERE domain_id = 'd_icd_procedures' AND vocabulary_id = 'MIMIC Local Codes'),
+"concept_proc_icd9" as ( SELECT concept_id as procedure_concept_id, concept_code FROM :OMOP_SCHEMA.concept WHERE vocabulary_id = 'ICD9Proc'),
 "patients" AS (SELECT subject_id, mimic_id as person_id FROM patients),
 "caregivers" AS (SELECT mimic_id AS provider_id, cgid FROM caregivers),
 "admissions" AS (SELECT hadm_id, admittime, dischtime as procedure_datetime, mimic_id as visit_occurrence_id FROM admissions),
@@ -21,12 +21,12 @@ WITH
 ),
 "gcpt_procedure_to_concept" as (SELECT item_id as itemid, concept_id as procedure_concept_id from gcpt_procedure_to_concept),
 "cpt_event" AS ( SELECT mimic_id as procedure_occurrence_id , subject_id , hadm_id , chartdate as procedure_datetime, cpt_cd, subsectionheader as procedure_source_value FROM cptevents),
-"omop_cpt4" as (SELECT concept_id as procedure_source_concept_id, concept_code as cpt_cd FROM omop.concept where vocabulary_id = 'CPT4'),
+":OMOP_SCHEMA_cpt4" as (SELECT concept_id as procedure_source_concept_id, concept_code as cpt_cd FROM :OMOP_SCHEMA.concept where vocabulary_id = 'CPT4'),
 "standard_cpt4" as (
 	select distinct on (c1.concept_id) first_value(c2.concept_id) over(partition by c1.concept_id order by relationship_id ASC) as procedure_concept_id, c1.concept_code as cpt_cd --keep snomed in predilection
-	from omop.concept c1
-	join omop.concept_relationship cr on concept_id_1 = c1.concept_id and relationship_id IN ('CPT4 - SNOMED eq','Maps to')
-	left join omop.concept c2 on concept_id_2 = c2.concept_id
+	from :OMOP_SCHEMA.concept c1
+	join :OMOP_SCHEMA.concept_relationship cr on concept_id_1 = c1.concept_id and relationship_id IN ('CPT4 - SNOMED eq','Maps to')
+	left join :OMOP_SCHEMA.concept c2 on concept_id_2 = c2.concept_id
 	WHERE
 	    c1.vocabulary_id ='CPT4'
 	and c2.standard_concept = 'S'
@@ -45,12 +45,12 @@ SELECT
 , admissions.visit_occurrence_id
 , null::integer as visit_detail_id -- the chartdate is never a time, when exist
 , cpt_event.procedure_source_value
-, omop_cpt4.procedure_source_concept_id as procedure_source_concept_id
+, :OMOP_SCHEMA_cpt4.procedure_source_concept_id as procedure_source_concept_id
 , null::text as modifier_source_value
 FROM cpt_event
 LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
-LEFT JOIN omop_cpt4 USING (cpt_cd)
+LEFT JOIN :OMOP_SCHEMA_cpt4 USING (cpt_cd)
 LEFT JOIN standard_cpt4 USING (cpt_cd)
 UNION ALL
 SELECT
@@ -73,7 +73,7 @@ LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 LEFT JOIN caregivers USING (cgid)
 LEFT JOIN gcpt_procedure_to_concept USING (itemid)
-LEFT JOIN omop.visit_detail_assign ON admissions.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
+LEFT JOIN :OMOP_SCHEMA.visit_detail_assign ON admissions.visit_occurrence_id = visit_detail_assign.visit_occurrence_id
 AND
 (--only one visit_detail
 (is_first IS TRUE AND is_last IS TRUE)
@@ -106,7 +106,7 @@ LEFT JOIN patients USING (subject_id)
 LEFT JOIN admissions USING (hadm_id)
 LEFT JOIN concept_proc_icd9 USING (concept_code)
 )
-INSERT INTO omop.procedure_occurrence
+INSERT INTO :OMOP_SCHEMA.procedure_occurrence
 (
     procedure_occurrence_id
   , person_id

--- a/etl/StandardizedClinicalDataTables/VISIT_DETAIL/etl.sql
+++ b/etl/StandardizedClinicalDataTables/VISIT_DETAIL/etl.sql
@@ -32,7 +32,7 @@ UNION ALL
        SELECT care_site.care_site_name
             , care_site.care_site_id
             , visit_detail_concept_id
-       FROM omop.care_site
+       FROM :OMOP_SCHEMA.care_site
        left join gcpt_care_site on gcpt_care_site.care_site_name = care_site.care_site_source_value
 ),
 "gcpt_admission_location_to_concept" AS (SELECT concept_id as admitting_source_concept_id, admission_location FROM gcpt_admission_location_to_concept),
@@ -92,7 +92,7 @@ UNION ALL
 	LEFT JOIN gcpt_discharge_location_to_concept USING (discharge_location)
 ),
 "insert_visit_detail_ward" AS (
-INSERT INTO omop.visit_detail
+INSERT INTO :OMOP_SCHEMA.visit_detail
 (
     visit_detail_id
   , person_id
@@ -159,7 +159,7 @@ LEFT JOIN gcpt_care_site USING (care_site_name)
 	WHERE callout_outcome not ilike 'cancel%' AND visit_detail_id IS NOT NULL
 ),
 "insert_callout_delay" AS (
-	INSERT INTO omop.cohort_attribute
+	INSERT INTO :OMOP_SCHEMA.cohort_attribute
   (
   	  cohort_definition_id
   	, cohort_start_date
@@ -180,7 +180,7 @@ LEFT JOIN gcpt_care_site USING (care_site_name)
 	FROM callout_delay
 ),
 "insert_visit_detail_delay" AS (
-	INSERT INTO omop.cohort_attribute
+	INSERT INTO :OMOP_SCHEMA.cohort_attribute
   (
   	  cohort_definition_id
   	, cohort_start_date
@@ -214,7 +214,7 @@ WITH
 	   care_site.care_site_name
 	 , care_site.care_site_id
 	 , visit_detail_concept_id
-	      FROM omop.care_site
+	      FROM :OMOP_SCHEMA.care_site
 	      LEFT JOIN gcpt_care_site on gcpt_care_site.care_site_name = care_site.care_site_source_value
 ),
 "admissions" AS (SELECT hadm_id, admission_location, discharge_location, mimic_id as visit_occurrence_id, admittime, dischtime FROM admissions),
@@ -317,8 +317,8 @@ FROM visit_detail_service;
 -- the way of assigning is quite simple right now
 -- but simple error is better than complicate error
 -- meaning, those links are artificial watever we do
- DROP TABLE IF EXISTS omop.visit_detail_assign;
- CREATE TABLE omop.visit_detail_assign AS
+ DROP TABLE IF EXISTS :OMOP_SCHEMA.visit_detail_assign;
+ CREATE TABLE :OMOP_SCHEMA.visit_detail_assign AS
  SELECT
    visit_detail_id
  , visit_occurrence_id
@@ -328,6 +328,6 @@ FROM visit_detail_service;
  , visit_detail_id = last_value(visit_detail_id) OVER(PARTITION BY visit_occurrence_id ORDER BY visit_start_datetime ASC range between current row and unbounded following) AS is_last
  , visit_detail_concept_id = 581382 AS is_icu
  , visit_detail_concept_id = 581381 AS is_emergency
- FROM  omop.visit_detail
+ FROM  :OMOP_SCHEMA.visit_detail
  WHERE visit_type_concept_id = 2000000006 -- only ward kind
  ;

--- a/etl/StandardizedClinicalDataTables/VISIT_OCCURRENCE/etl.sql
+++ b/etl/StandardizedClinicalDataTables/VISIT_OCCURRENCE/etl.sql
@@ -22,8 +22,8 @@ WITH
 "gcpt_admission_type_to_concept" AS (SELECT mimic_id as visit_source_concept_id, admission_type as visit_source_value FROM gcpt_admission_type_to_concept),
 "gcpt_admission_location_to_concept" AS (SELECT concept_id as admitting_concept_id, mimic_id as admitting_source_concept_id, admission_location FROM gcpt_admission_location_to_concept),
 "gcpt_discharge_location_to_concept" AS (SELECT concept_id as discharge_to_concept_id, mimic_id as discharge_to_source_concept_id, discharge_location FROM gcpt_discharge_location_to_concept),
-"care_site" as (select care_site_id from omop.care_site where care_site_name = 'BIDMC') -- Beth Israel hospital for all
- INSERT INTO omop.VISIT_OCCURRENCE
+"care_site" as (select care_site_id from :OMOP_SCHEMA.care_site where care_site_name = 'BIDMC') -- Beth Israel hospital for all
+ INSERT INTO :OMOP_SCHEMA.VISIT_OCCURRENCE
  (
       visit_occurrence_id
     , person_id

--- a/etl/StandardizedDerivedElements/DOSE_ERA/etl.sql
+++ b/etl/StandardizedDerivedElements/DOSE_ERA/etl.sql
@@ -14,7 +14,7 @@ WITH
 , valid_start_date
 , valid_end_date
 , invalid_reason
-FROM omop.drug_strength
+FROM :OMOP_SCHEMA.drug_strength
 WHERE amount_value is not null
 ),
 "prescription_written" as (
@@ -42,7 +42,7 @@ WHERE amount_value is not null
 , drug_source_concept_id
 , route_source_value
 , dose_unit_source_value
-FROM omop.drug_exposure
+FROM :OMOP_SCHEMA.drug_exposure
 WHERE TRUE
 AND drug_type_concept_id = 38000177   -- concept.concept_name = 'Prescription written'
 AND dose_unit_source_value IN ('TAB', 'mg', 'g', 'dose', 'SUPP', 'TAB', 'LOZ', 'TROC')
@@ -65,7 +65,7 @@ nextval('mimic_id_seq') as dose_era_id
 FROM prescription_written drug_exposure
 INNER JOIN drug_strength USING (drug_concept_id)
 )
-INSERT INTO omop.dose_era
+INSERT INTO :OMOP_SCHEMA.dose_era
 SELECT
   dose_era_id         
 , person_id           
@@ -111,7 +111,7 @@ drug_exposure_id
 , quantity_source_value
 , unit_concept_id
 , temporal_unit_concept_id
-FROM omop.drug_exposure
+FROM :OMOP_SCHEMA.drug_exposure
 INNER JOIN 
 	(SELECT label AS dose_unit_source_value, unit_concept_id, temporal_unit_concept_id 
 	FROM  gcpt_unit_doseera_concept_id) --mEq, mEQ ...
@@ -121,7 +121,7 @@ AND drug_type_concept_id = 38000180   -- concept.concept_name = 'Inpatient admin
 AND quantity IS NOT NULL
 AND drug_concept_id != 0
 )
-INSERT INTO omop.dose_era
+INSERT INTO :OMOP_SCHEMA.dose_era
 SELECT
 nextval('mimic_id_seq') as dose_era_id
 , person_id           

--- a/etl/StandardizedHealthSystemDataTables/CARE_SITE/etl.sql
+++ b/etl/StandardizedHealthSystemDataTables/CARE_SITE/etl.sql
@@ -16,7 +16,7 @@
  left join wardid on care_site_name = curr_careunit
 ),
 "insert_relationship_itself" AS (
-	INSERT INTO omop.fact_relationship
+	INSERT INTO :OMOP_SCHEMA.fact_relationship
 	(domain_concept_id_1, fact_id_1, domain_concept_id_2, fact_id_2, relationship_concept_id)
 SELECT
   57 AS domain_concept_id_1 -- 57    Care site
@@ -27,7 +27,7 @@ SELECT
 FROM gcpt_care_site
 ),
 "insert_relationship_ward_hospit" AS ( --link the wards to BIDMC hospital
-	INSERT INTO omop.fact_relationship
+	INSERT INTO :OMOP_SCHEMA.fact_relationship
 	(domain_concept_id_1, fact_id_1, domain_concept_id_2, fact_id_2, relationship_concept_id)
 SELECT
   57 AS domain_concept_id_1 -- 57    Care site
@@ -39,7 +39,7 @@ FROM gcpt_care_site gc1
 JOIN gcpt_care_site gc2 ON gc2.care_site_name = 'BIDMC' 
 WHERE gc1.care_site_name ~ ' ward '
 )
-INSERT INTO omop.CARE_SITE
+INSERT INTO :OMOP_SCHEMA.CARE_SITE
 (
    care_site_id
  , care_site_name

--- a/etl/StandardizedHealthSystemDataTables/PROVIDER/etl.sql
+++ b/etl/StandardizedHealthSystemDataTables/PROVIDER/etl.sql
@@ -1,5 +1,5 @@
 WITH caregivers AS (SELECT mimic_id as provider_id, label as provider_source_value, description as specialty_source_value FROM caregivers)
-INSERT INTO omop.PROVIDER
+INSERT INTO :OMOP_SCHEMA.PROVIDER
 (
   provider_id
  , provider_source_value

--- a/etl/StandardizedVocabularies/CONCEPT/etl.sql
+++ b/etl/StandardizedVocabularies/CONCEPT/etl.sql
@@ -1,11 +1,11 @@
-ALTER TABLE omop.concept DISABLE TRIGGER ALL;
-DELETE FROM omop.concept WHERE concept_id >= 200000000;
-DELETE FROM omop.concept_synonym WHERE concept_id >= 200000000;
-ALTER TABLE omop.concept ENABLE TRIGGER ALL;
+ALTER TABLE :OMOP_SCHEMA.concept DISABLE TRIGGER ALL;
+DELETE FROM :OMOP_SCHEMA.concept WHERE concept_id >= 200000000;
+DELETE FROM :OMOP_SCHEMA.concept_synonym WHERE concept_id >= 200000000;
+ALTER TABLE :OMOP_SCHEMA.concept ENABLE TRIGGER ALL;
 
 --MIMIC-OMOP
 --concept_
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, concept_code, valid_start_date, valid_end_date
 ) VALUES
   (2000000000,'Stroke Volume Variation','Measurement','','Clinical Observation','MIMIC Generated','1979-01-01','2099-01-01')
@@ -24,7 +24,7 @@ concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, concept_co
 , (2000000013,'Unwkown Ward','Visit Detail','Visit Detail','Visit_detail','MIMIC Generated','1979-01-01','2099-01-01')
 ;
 
--- INSERT INTO omop.concept_relationship()
+-- INSERT INTO :OMOP_SCHEMA.concept_relationship()
 -- VALUES
 
 
@@ -33,7 +33,7 @@ concept_id, concept_name, domain_id, vocabulary_id, concept_class_id, concept_co
 
 
 --ITEMS
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -106,7 +106,7 @@ SELECT
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
 FROM d_items;
-INSERT INTO omop.concept_synonym
+INSERT INTO :OMOP_SCHEMA.concept_synonym
 (
   concept_id
 , concept_synonym_name
@@ -153,7 +153,7 @@ and abbreviation is not null;
 --	)
 
 --LABS
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -161,7 +161,7 @@ SELECT
 , 'label:[' || coalesce(label,'') || ']fluid:[' || coalesce(fluid,'') || ']loinc:[' || coalesce(loinc_code,'') || ']' as concept_name
 , 'Measurement'::text as domain_id
 , 'MIMIC d_labitems' as vocabulary_id
-, coalesce(category,'') as concept_class_id -- omop Lab Test
+, coalesce(category,'') as concept_class_id -- :OMOP_SCHEMA Lab Test
 , itemid::Text as concept_code
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
@@ -198,7 +198,7 @@ distinct on (concept_name)
 FROM tmp
 ),
 "insert_synonym" as  (
-INSERT INTO omop.concept_synonym
+INSERT INTO :OMOP_SCHEMA.concept_synonym
 (
   concept_id
 , concept_synonym_name
@@ -220,7 +220,7 @@ from row_to_insert
 WHERE drug_name_generic is distinct from drug
 and drug_name_generic is not null
 )
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -236,7 +236,7 @@ FROM row_to_insert;
 
 --d_icd_procedures
 
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -249,7 +249,7 @@ SELECT
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
 FROM d_icd_procedures;
-INSERT INTO omop.concept_synonym
+INSERT INTO :OMOP_SCHEMA.concept_synonym
 (
   concept_id
 , concept_synonym_name
@@ -265,7 +265,7 @@ and long_title IS NOT NULL;
 
 
 -- NOTE_NLP sections
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -273,14 +273,14 @@ SELECT
 , label as concept_name
 , 'Note Nlp'::text as domain_id
 , 'MIMIC Generated' as vocabulary_id
-, 'Section' as concept_class_id -- omop Lab Test
+, 'Section' as concept_class_id -- :OMOP_SCHEMA Lab Test
 , section_id as concept_code
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
 FROM gcpt_note_section_to_concept;
 
 -- NOTE_NLP mapped sections
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -288,14 +288,14 @@ SELECT
 , label_mapped as concept_name
 , 'Note Nlp'::text as domain_id
 ,  category as vocabulary_id
-, 'Section' as concept_class_id -- omop Lab Test
+, 'Section' as concept_class_id -- :OMOP_SCHEMA Lab Test
 , 'MIMIC Generated' as concept_code
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
 FROM gcpt_note_section_to_concept;
 
 -- Derived values
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -303,14 +303,14 @@ SELECT
 , measurement_source_value as concept_name
 , 'Meas Value'::text as domain_id
 , 'MIMIC Generated' as vocabulary_id
-, 'Derived Value' as concept_class_id -- omop Lab Test
+, 'Derived Value' as concept_class_id -- :OMOP_SCHEMA Lab Test
 ,  itemid as concept_code
 , '1979-01-01' as valid_start_date
 , '2099-01-01' as valid_end_date
 FROM gcpt_derived_to_concept;
 
 --visit_occurrence_admitting
-INSERT INTO omop.concept (
+INSERT INTO :OMOP_SCHEMA.concept (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT
@@ -326,7 +326,7 @@ FROM gcpt_admission_location_to_concept;
 
 
 --visit_occurrence_discharge
-INSERT INTO omop.concept  (
+INSERT INTO :OMOP_SCHEMA.concept  (
 concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,concept_code,valid_start_date,valid_end_date
 )
 SELECT

--- a/etl/etl.sql
+++ b/etl/etl.sql
@@ -42,7 +42,6 @@ TRUNCATE TABLE  :OMOP_SCHEMA.dose_era CASCADE;
 \i etl/StandardizedClinicalDataTables/MEASUREMENT/etl.sql
 \i etl/StandardizedClinicalDataTables/SPECIMEN/etl.sql
 \i etl/StandardizedDerivedElements/DOSE_ERA/etl.sql
-*/
 --\i omop/build-omop/postgresql/mimic-omop-enable-trigger.sql
 --ROLLBACK;
 --COMMIT;

--- a/etl/etl.sql
+++ b/etl/etl.sql
@@ -1,32 +1,32 @@
 --BEGIN;
-\set ON_ERROR_STOP true
+\set ON_ERROR_STOP false
 \timing
 
-TRUNCATE TABLE  omop.care_site CASCADE;
-TRUNCATE TABLE  omop.cohort_definition CASCADE;
-TRUNCATE TABLE  omop.cohort_attribute CASCADE;
-TRUNCATE TABLE  omop.attribute_definition CASCADE;
-TRUNCATE TABLE  omop.person CASCADE;
-TRUNCATE TABLE  omop.death CASCADE;
-TRUNCATE TABLE  omop.visit_occurrence CASCADE;
-TRUNCATE TABLE  omop.observation_period CASCADE;
-TRUNCATE TABLE  omop.visit_detail CASCADE;
-TRUNCATE TABLE  omop.procedure_occurrence CASCADE;
-TRUNCATE TABLE  omop.provider CASCADE;
-TRUNCATE TABLE  omop.condition_occurrence CASCADE;
-TRUNCATE TABLE  omop.observation CASCADE;
-TRUNCATE TABLE  omop.drug_exposure CASCADE;
-TRUNCATE TABLE  omop.measurement CASCADE;
-TRUNCATE TABLE  omop.specimen CASCADE;
-TRUNCATE TABLE  omop.note CASCADE;
-TRUNCATE TABLE  omop.note_nlp CASCADE;
-TRUNCATE TABLE  omop.fact_relationship CASCADE;
-TRUNCATE TABLE  omop.dose_era CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.care_site CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.cohort_definition CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.cohort_attribute CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.attribute_definition CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.person CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.death CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.visit_occurrence CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.observation_period CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.visit_detail CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.procedure_occurrence CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.provider CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.condition_occurrence CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.observation CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.drug_exposure CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.measurement CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.specimen CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.note CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.note_nlp CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.fact_relationship CASCADE;
+TRUNCATE TABLE  :OMOP_SCHEMA.dose_era CASCADE;
 
 
 --\i omop/build-omop/postgresql/mimic-omop-disable-trigger.sql
 \i etl/pg_function.sql
-\i etl/StandardizedVocabularies/CONCEPT/etl.sql -- SHALL be first loaded table
+\i etl/StandardizedVocabularies/CONCEPT/etl.sql
 \i etl/StandardizedHealthSystemDataTables/CARE_SITE/etl.sql
 \i etl/StandardizedHealthSystemDataTables/PROVIDER/etl.sql
 \i etl/StandardizedClinicalDataTables/PERSON/etl.sql
@@ -42,7 +42,7 @@ TRUNCATE TABLE  omop.dose_era CASCADE;
 \i etl/StandardizedClinicalDataTables/MEASUREMENT/etl.sql
 \i etl/StandardizedClinicalDataTables/SPECIMEN/etl.sql
 \i etl/StandardizedDerivedElements/DOSE_ERA/etl.sql
-
+*/
 --\i omop/build-omop/postgresql/mimic-omop-enable-trigger.sql
 --ROLLBACK;
 --COMMIT;

--- a/omop/build-omop/postgresql/README.md
+++ b/omop/build-omop/postgresql/README.md
@@ -71,13 +71,13 @@ Import the vocabulary:
 psql "$OMOP" -f "omop/build-omop/postgresql/omop_vocab_load.sql"
 ```
 
-(Optional, recommended) Build indexes and primary key constraints:
+(Optional) Indexes may slow down importing of data - so you may want to only build these *after* running the full ETL.
 
 ```bash
 psql "$OMOP" -f "omop/build-omop/postgresql/OMOP CDM postgresql indexes.txt"
 ```
 
-(Optional, experimental) Build foreign key constraints (slows things down usually but can be useful to ensure integrity of data):
+(Optional, experimental) For a similar reason as above, you may want to run this after the full ETL. Note also that since the foreign keys were not used during the construction of the ETL, they may have been violated by the process.
 
 ```bash
 psql "$OMOP" -f "omop/build-omop/postgresql/OMOP CDM postgresql constraints.txt"

--- a/omop/build-omop/postgresql/mimic-omop-alter.sql
+++ b/omop/build-omop/postgresql/mimic-omop-alter.sql
@@ -8,8 +8,8 @@ ALTER TABLE observation_period ADD COLUMN "observation_period_end_datetime" TIME
 ALTER TABLE visit_occurrence ADD COLUMN "admitting_concept_id" INTEGER NULL ;
 ALTER TABLE visit_occurrence ADD COLUMN "discharge_to_source_concept_id" INTEGER NULL ;
 
-ALTER TABLE visit_detail ADD COLUMN visit_detail_source_value" VARCHAR(50) NULL ;
-ALTER TABLE visit_detail ADD COLUMN visit_detail_source_concept_id" INTEGER NULL ;
+ALTER TABLE visit_detail ADD COLUMN "visit_detail_source_value" VARCHAR(50) NULL ;
+ALTER TABLE visit_detail ADD COLUMN "visit_detail_source_concept_id" INTEGER NULL ;
 ALTER TABLE visit_detail ADD COLUMN "admitting_concept_id" INTEGER NULL ;
 ALTER TABLE visit_detail ADD COLUMN "discharge_to_source_concept_id" INTEGER NULL;
 

--- a/omop/build-omop/postgresql/mimic-omop-alter.sql
+++ b/omop/build-omop/postgresql/mimic-omop-alter.sql
@@ -15,54 +15,54 @@ ALTER TABLE visit_detail ADD COLUMN "discharge_to_source_concept_id" INTEGER NUL
 
 
 -- those are usefull
-ALTER TABLE omop.dose_era ADD COLUMN temporal_unit_concept_id integer;
-COMMENT ON COLUMN omop.dose_era.temporal_unit_concept_id  IS 'Stores temporal unit, daily, hourly ...';
+ALTER TABLE .dose_era ADD COLUMN temporal_unit_concept_id integer;
+COMMENT ON COLUMN .dose_era.temporal_unit_concept_id  IS 'Stores temporal unit, daily, hourly ...';
 
-ALTER TABLE omop.dose_era ADD COLUMN temporal_value numeric;
-COMMENT ON COLUMN omop.dose_era.temporal_value IS 'Stores temporal value';
+ALTER TABLE .dose_era ADD COLUMN temporal_value numeric;
+COMMENT ON COLUMN .dose_era.temporal_value IS 'Stores temporal value';
 
-ALTER TABLE omop.drug_exposure ADD COLUMN quantity_source_value text ;
-COMMENT ON COLUMN omop.drug_exposure.quantity_source_value IS 'Stores the source quantity value';
+ALTER TABLE .drug_exposure ADD COLUMN quantity_source_value text ;
+COMMENT ON COLUMN .drug_exposure.quantity_source_value IS 'Stores the source quantity value';
 
 -- Below are columns we are considering adding
 
---ALTER TABLE omop.death ADD COLUMN visit_detail_id BIGINT;
---COMMENT ON COLUMN omop.death.visit_detail_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_DETAIL table during where the death occured';
+--ALTER TABLE .death ADD COLUMN visit_detail_id BIGINT;
+--COMMENT ON COLUMN .death.visit_detail_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_DETAIL table during where the death occured';
 
---ALTER TABLE omop.death ADD COLUMN visit_occurrence_id BIGINT;
---COMMENT ON COLUMN omop.death.visit_occurrence_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_OCCURRENCE table during where the death occured';
+--ALTER TABLE .death ADD COLUMN visit_occurrence_id BIGINT;
+--COMMENT ON COLUMN .death.visit_occurrence_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_OCCURRENCE table during where the death occured';
 --
---ALTER TABLE omop.death ADD COLUMN death_visit_detail_delay double precision;
---COMMENT ON COLUMN omop.death.death_visit_detail_delay             IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_DETAIL table';
+--ALTER TABLE .death ADD COLUMN death_visit_detail_delay double precision;
+--COMMENT ON COLUMN .death.death_visit_detail_delay             IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_DETAIL table';
 --
---ALTER TABLE omop.death ADD COLUMN death_visit_occurrence_delay double precision;
---COMMENT ON COLUMN omop.death.death_visit_occurrence_delay      IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_OCCURRENCE table';
+--ALTER TABLE .death ADD COLUMN death_visit_occurrence_delay double precision;
+--COMMENT ON COLUMN .death.death_visit_occurrence_delay      IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_OCCURRENCE table';
 --
---ALTER TABLE omop.measurement ADD COLUMN quality_concept_id bigint;
---COMMENT ON COLUMN omop.measurement.quality_concept_id             IS '[CONTRIB] Quality mask, can be queried with regex, to filter based on quality aspects';
+--ALTER TABLE .measurement ADD COLUMN quality_concept_id bigint;
+--COMMENT ON COLUMN .measurement.quality_concept_id             IS '[CONTRIB] Quality mask, can be queried with regex, to filter based on quality aspects';
 --
---ALTER TABLE omop.visit_occurrence ADD COLUMN age_in_year integer;
---COMMENT ON COLUMN omop.visit_occurrence.age_in_year             IS '[CONTRIB] Age at visit';
+--ALTER TABLE .visit_occurrence ADD COLUMN age_in_year integer;
+--COMMENT ON COLUMN .visit_occurrence.age_in_year             IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE omop.visit_occurrence ADD COLUMN age_in_month integer;
---COMMENT ON COLUMN omop.visit_occurrence.age_in_month             IS '[CONTRIB] Age at visit';
+--ALTER TABLE .visit_occurrence ADD COLUMN age_in_month integer;
+--COMMENT ON COLUMN .visit_occurrence.age_in_month             IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE omop.visit_occurrence ADD COLUMN age_in_day integer;
---COMMENT ON COLUMN omop.visit_occurrence.age_in_day IS '[CONTRIB] Age at visit';
+--ALTER TABLE .visit_occurrence ADD COLUMN age_in_day integer;
+--COMMENT ON COLUMN .visit_occurrence.age_in_day IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE omop.visit_occurrence ADD COLUMN visit_occurrence_length double precision;
---COMMENT ON COLUMN omop.visit_occurrence.visit_occurrence_length IS '[CONTRIB] Length of visit occurrence';
+--ALTER TABLE .visit_occurrence ADD COLUMN visit_occurrence_length double precision;
+--COMMENT ON COLUMN .visit_occurrence.visit_occurrence_length IS '[CONTRIB] Length of visit occurrence';
 --
---ALTER TABLE omop.visit_detail ADD COLUMN visit_detail_length double precision;
---COMMENT ON COLUMN omop.visit_detail.visit_detail_length IS '[CONTRIB] Length of visit detail';
+--ALTER TABLE .visit_detail ADD COLUMN visit_detail_length double precision;
+--COMMENT ON COLUMN .visit_detail.visit_detail_length IS '[CONTRIB] Length of visit detail';
 --
---ALTER TABLE omop.visit_detail ADD COLUMN discharge_delay double precision;
---COMMENT ON COLUMN omop.visit_detail.discharge_delay IS '[CONTRIB] Delay between discharge decision and effective discharge';
+--ALTER TABLE .visit_detail ADD COLUMN discharge_delay double precision;
+--COMMENT ON COLUMN .visit_detail.discharge_delay IS '[CONTRIB] Delay between discharge decision and effective discharge';
 
 
 -- there is actually no need to limit the character size in postgres.
 -- limiting them is error prone and does not improve any performances or etl security
--- the omop spec says it is possible to alter the text length
+-- the  spec says it is possible to alter the text length
 
 -- SELECT
 --     'ALTER TABLE '||columns.table_name||' ALTER COLUMN   '||columns.column_name||' TYPE text;'
@@ -70,7 +70,7 @@ COMMENT ON COLUMN omop.drug_exposure.quantity_source_value IS 'Stores the source
 --     information_schema.columns
 --  WHERE
 --    columns.table_catalog = 'mimic' AND
---    columns.table_schema = 'omop' AND
+--    columns.table_schema = '' AND
 --    columns.data_type ilike 'character%';
  ALTER TABLE attribute_definition ALTER COLUMN   attribute_name TYPE text;
  ALTER TABLE cdm_source ALTER COLUMN   cdm_source_name TYPE text;
@@ -204,7 +204,7 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 --    information_schema.columns
 -- WHERE
 --   columns.table_catalog = 'mimic' AND
---   columns.table_schema = 'omop' AND
+--   columns.table_schema = '' AND
 --   columns.data_type = 'integer';
 -- ALTER TABLE concept_class ALTER COLUMN   concept_class_concept_id TYPE bigint;
 -- ALTER TABLE source_to_concept_map ALTER COLUMN   source_concept_id TYPE bigint;

--- a/omop/build-omop/postgresql/mimic-omop-alter.sql
+++ b/omop/build-omop/postgresql/mimic-omop-alter.sql
@@ -8,56 +8,56 @@ ALTER TABLE observation_period ADD COLUMN "observation_period_end_datetime" TIME
 ALTER TABLE visit_occurrence ADD COLUMN "admitting_concept_id" INTEGER NULL ;
 ALTER TABLE visit_occurrence ADD COLUMN "discharge_to_source_concept_id" INTEGER NULL ;
 
-ALTER TABLE visit_detail ADD COLUMN "visit_detail_source_value" VARCHAR(50) NULL ;
-ALTER TABLE visit_detail ADD COLUMN "visit_detail_source_concept_id" INTEGER NULL ;
+ALTER TABLE visit_detail ADD COLUMN visit_detail_source_value" VARCHAR(50) NULL ;
+ALTER TABLE visit_detail ADD COLUMN visit_detail_source_concept_id" INTEGER NULL ;
 ALTER TABLE visit_detail ADD COLUMN "admitting_concept_id" INTEGER NULL ;
 ALTER TABLE visit_detail ADD COLUMN "discharge_to_source_concept_id" INTEGER NULL;
 
 
 -- those are usefull
-ALTER TABLE .dose_era ADD COLUMN temporal_unit_concept_id integer;
-COMMENT ON COLUMN .dose_era.temporal_unit_concept_id  IS 'Stores temporal unit, daily, hourly ...';
+ALTER TABLE dose_era ADD COLUMN temporal_unit_concept_id integer;
+COMMENT ON COLUMN dose_era.temporal_unit_concept_id  IS 'Stores temporal unit, daily, hourly ...';
 
-ALTER TABLE .dose_era ADD COLUMN temporal_value numeric;
-COMMENT ON COLUMN .dose_era.temporal_value IS 'Stores temporal value';
+ALTER TABLE dose_era ADD COLUMN temporal_value numeric;
+COMMENT ON COLUMN dose_era.temporal_value IS 'Stores temporal value';
 
-ALTER TABLE .drug_exposure ADD COLUMN quantity_source_value text ;
-COMMENT ON COLUMN .drug_exposure.quantity_source_value IS 'Stores the source quantity value';
+ALTER TABLE drug_exposure ADD COLUMN quantity_source_value text ;
+COMMENT ON COLUMN drug_exposure.quantity_source_value IS 'Stores the source quantity value';
 
 -- Below are columns we are considering adding
 
---ALTER TABLE .death ADD COLUMN visit_detail_id BIGINT;
---COMMENT ON COLUMN .death.visit_detail_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_DETAIL table during where the death occured';
+--ALTER TABLE death ADD COLUMN visit_detail_id BIGINT;
+--COMMENT ON COLUMN death.visit_detail_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_DETAIL table during where the death occured';
 
---ALTER TABLE .death ADD COLUMN visit_occurrence_id BIGINT;
---COMMENT ON COLUMN .death.visit_occurrence_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_OCCURRENCE table during where the death occured';
+--ALTER TABLE death ADD COLUMN visit_occurrence_id BIGINT;
+--COMMENT ON COLUMN death.visit_occurrence_id             IS '[CONTRIB] A foreign key to the visit in the VISIT_OCCURRENCE table during where the death occured';
 --
---ALTER TABLE .death ADD COLUMN death_visit_detail_delay double precision;
---COMMENT ON COLUMN .death.death_visit_detail_delay             IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_DETAIL table';
+--ALTER TABLE death ADD COLUMN death_visit_detail_delay double precision;
+--COMMENT ON COLUMN death.death_visit_detail_delay             IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_DETAIL table';
 --
---ALTER TABLE .death ADD COLUMN death_visit_occurrence_delay double precision;
---COMMENT ON COLUMN .death.death_visit_occurrence_delay      IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_OCCURRENCE table';
+--ALTER TABLE death ADD COLUMN death_visit_occurrence_delay double precision;
+--COMMENT ON COLUMN death.death_visit_occurrence_delay      IS '[CONTRIB] Difference between deathtime and visit_start_datetime of VISIT_OCCURRENCE table';
 --
---ALTER TABLE .measurement ADD COLUMN quality_concept_id bigint;
---COMMENT ON COLUMN .measurement.quality_concept_id             IS '[CONTRIB] Quality mask, can be queried with regex, to filter based on quality aspects';
+--ALTER TABLE measurement ADD COLUMN quality_concept_id bigint;
+--COMMENT ON COLUMN measurement.quality_concept_id             IS '[CONTRIB] Quality mask, can be queried with regex, to filter based on quality aspects';
 --
---ALTER TABLE .visit_occurrence ADD COLUMN age_in_year integer;
---COMMENT ON COLUMN .visit_occurrence.age_in_year             IS '[CONTRIB] Age at visit';
+--ALTER TABLE visit_occurrence.ADD COLUMN age_in_year integer;
+--COMMENT ON COLUMN visit_occurrence.age_in_year             IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE .visit_occurrence ADD COLUMN age_in_month integer;
---COMMENT ON COLUMN .visit_occurrence.age_in_month             IS '[CONTRIB] Age at visit';
+--ALTER TABLE visit_occurrence.ADD COLUMN age_in_month integer;
+--COMMENT ON COLUMN visit_occurrence.age_in_month             IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE .visit_occurrence ADD COLUMN age_in_day integer;
---COMMENT ON COLUMN .visit_occurrence.age_in_day IS '[CONTRIB] Age at visit';
+--ALTER TABLE visit_occurrence.ADD COLUMN age_in_day integer;
+--COMMENT ON COLUMN visit_occurrence.age_in_day IS '[CONTRIB] Age at visit';
 --
---ALTER TABLE .visit_occurrence ADD COLUMN visit_occurrence_length double precision;
---COMMENT ON COLUMN .visit_occurrence.visit_occurrence_length IS '[CONTRIB] Length of visit occurrence';
+--ALTER TABLE visit_occurrence.ADD COLUMN visit_occurrence_length double precision;
+--COMMENT ON COLUMN visit_occurrence.visit_occurrence_length IS '[CONTRIB] Length of visit occurrence';
 --
---ALTER TABLE .visit_detail ADD COLUMN visit_detail_length double precision;
---COMMENT ON COLUMN .visit_detail.visit_detail_length IS '[CONTRIB] Length of visit detail';
+--ALTER TABLE visit_detail ADD COLUMN visit_detail_length double precision;
+--COMMENT ON COLUMN visit_detail.visit_detail_length IS '[CONTRIB] Length of visit detail';
 --
---ALTER TABLE .visit_detail ADD COLUMN discharge_delay double precision;
---COMMENT ON COLUMN .visit_detail.discharge_delay IS '[CONTRIB] Delay between discharge decision and effective discharge';
+--ALTER TABLE visit_detail ADD COLUMN discharge_delay double precision;
+--COMMENT ON COLUMN visit_detail.discharge_delay IS '[CONTRIB] Delay between discharge decision and effective discharge';
 
 
 -- there is actually no need to limit the character size in postgres.
@@ -163,7 +163,7 @@ ALTER TABLE specimen ALTER COLUMN   specimen_source_id TYPE text;
  ALTER TABLE cost ALTER COLUMN   drg_source_value TYPE text;
  ALTER TABLE device_exposure ALTER COLUMN   unique_device_id TYPE text;
  ALTER TABLE device_exposure ALTER COLUMN   device_source_value TYPE text;
- ALTER TABLE measurement ALTER COLUMN   measurement_source_value TYPE text;
+ ALTER TABLE measurement ALTER COLUMN  measurement_source_value TYPE text;
  ALTER TABLE measurement ALTER COLUMN   unit_source_value TYPE text;
  ALTER TABLE measurement ALTER COLUMN   value_source_value TYPE text;
  ALTER TABLE visit_occurrence ALTER COLUMN   visit_source_value TYPE text;
@@ -209,28 +209,28 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE concept_class ALTER COLUMN   concept_class_concept_id TYPE bigint;
 -- ALTER TABLE source_to_concept_map ALTER COLUMN   source_concept_id TYPE bigint;
 -- ALTER TABLE source_to_concept_map ALTER COLUMN   target_concept_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   measurement_id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  measurement_id TYPE bigint;
 -- ALTER TABLE measurement ALTER COLUMN   person_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   measurement_concept_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   measurement_type_concept_id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  measurement_concept_id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  measurement_type_concept_id TYPE bigint;
 -- ALTER TABLE measurement ALTER COLUMN   operator_concept_id TYPE bigint;
 -- ALTER TABLE measurement ALTER COLUMN   value_as_concept_id TYPE bigint;
 -- ALTER TABLE measurement ALTER COLUMN   unit_concept_id TYPE bigint;
 -- ALTER TABLE measurement ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   visit_detail_id TYPE bigint;
--- ALTER TABLE measurement ALTER COLUMN   measurement_source_concept_id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  visit_detail_id TYPE bigint;
+-- ALTER TABLE measurement ALTER COLUMN  measurement_source_concept_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   device_exposure_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   person_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   device_concept_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   device_type_concept_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   quantity TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE device_exposure ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE device_exposure ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE device_exposure ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE device_exposure ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE device_exposure ALTER COLUMN   device_source_concept_id TYPE bigint;
 -- ALTER TABLE vocabulary ALTER COLUMN   vocabulary_concept_id TYPE bigint;
--- ALTER TABLE visit_occurrence ALTER COLUMN   visit_occurrence_id TYPE bigint;
+-- ALTER TABLE visit_occurrence ALTER COLUMN  visit_occurrence.id TYPE bigint;
 -- ALTER TABLE visit_occurrence ALTER COLUMN   person_id TYPE bigint;
 -- ALTER TABLE visit_occurrence ALTER COLUMN   visit_concept_id TYPE bigint;
 -- ALTER TABLE visit_occurrence ALTER COLUMN   visit_type_concept_id TYPE bigint;
@@ -306,16 +306,16 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE condition_occurrence ALTER COLUMN   condition_concept_id TYPE bigint;
 -- ALTER TABLE condition_occurrence ALTER COLUMN   condition_type_concept_id TYPE bigint;
 -- ALTER TABLE condition_occurrence ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE condition_occurrence ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE condition_occurrence ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE condition_occurrence ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE condition_occurrence ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE condition_occurrence ALTER COLUMN   condition_source_concept_id TYPE bigint;
 -- ALTER TABLE condition_occurrence ALTER COLUMN   condition_status_concept_id TYPE bigint;
 -- ALTER TABLE observation_period ALTER COLUMN   observation_period_id TYPE bigint;
 -- ALTER TABLE observation_period ALTER COLUMN   person_id TYPE bigint;
 -- ALTER TABLE observation_period ALTER COLUMN   period_type_concept_id TYPE bigint;
--- ALTER TABLE visit_detail ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE visit_detail ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   person_id TYPE bigint;
--- ALTER TABLE visit_detail ALTER COLUMN   visit_detail_concept_id TYPE bigint;
+-- ALTER TABLE visit_detail ALTER COLUMN  visit_detail_concept_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   visit_type_concept_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   provider_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   care_site_id TYPE bigint;
@@ -323,8 +323,8 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE visit_detail ALTER COLUMN   admitting_concept_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   discharge_to_concept_id TYPE bigint;
 -- ALTER TABLE visit_detail ALTER COLUMN   preceding_visit_detail_id TYPE bigint;
--- ALTER TABLE visit_detail ALTER COLUMN   visit_detail_parent_id TYPE bigint;
--- ALTER TABLE visit_detail ALTER COLUMN   visit_occurrence_id TYPE bigint;
+-- ALTER TABLE visit_detail ALTER COLUMN  visit_detail_parent_id TYPE bigint;
+-- ALTER TABLE visit_detail ALTER COLUMN  visit_occurrence.id TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   drug_exposure_id TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   person_id TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   drug_concept_id TYPE bigint;
@@ -333,8 +333,8 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE drug_exposure ALTER COLUMN   days_supply TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   route_concept_id TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE drug_exposure ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE drug_exposure ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE drug_exposure ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE drug_exposure ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE drug_exposure ALTER COLUMN   drug_source_concept_id TYPE bigint;
 -- ALTER TABLE note ALTER COLUMN   note_id TYPE bigint;
 -- ALTER TABLE note ALTER COLUMN   person_id TYPE bigint;
@@ -343,8 +343,8 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE note ALTER COLUMN   encoding_concept_id TYPE bigint;
 -- ALTER TABLE note ALTER COLUMN   language_concept_id TYPE bigint;
 -- ALTER TABLE note ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE note ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE note ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE note ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE note ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE location ALTER COLUMN   location_id TYPE bigint;
 -- ALTER TABLE cohort_definition ALTER COLUMN   cohort_definition_id TYPE bigint;
 -- ALTER TABLE cohort_definition ALTER COLUMN   definition_type_concept_id TYPE bigint;
@@ -357,8 +357,8 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE observation ALTER COLUMN   qualifier_concept_id TYPE bigint;
 -- ALTER TABLE observation ALTER COLUMN   unit_concept_id TYPE bigint;
 -- ALTER TABLE observation ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE observation ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE observation ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE observation ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE observation ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE observation ALTER COLUMN   observation_source_concept_id TYPE bigint;
 -- ALTER TABLE provider ALTER COLUMN   provider_id TYPE bigint;
 -- ALTER TABLE provider ALTER COLUMN   specialty_concept_id TYPE bigint;
@@ -383,8 +383,8 @@ ALTER TABLE note_nlp ADD COLUMN "section_source_concept_id" integer ;
 -- ALTER TABLE procedure_occurrence ALTER COLUMN   modifier_concept_id TYPE bigint;
 -- ALTER TABLE procedure_occurrence ALTER COLUMN   quantity TYPE bigint;
 -- ALTER TABLE procedure_occurrence ALTER COLUMN   provider_id TYPE bigint;
--- ALTER TABLE procedure_occurrence ALTER COLUMN   visit_occurrence_id TYPE bigint;
--- ALTER TABLE procedure_occurrence ALTER COLUMN   visit_detail_id TYPE bigint;
+-- ALTER TABLE procedure_occurrence ALTER COLUMN  visit_occurrence.id TYPE bigint;
+-- ALTER TABLE procedure_occurrence ALTER COLUMN  visit_detail_id TYPE bigint;
 -- ALTER TABLE procedure_occurrence ALTER COLUMN   procedure_source_concept_id TYPE bigint;
 -- ALTER TABLE person ALTER COLUMN   person_id TYPE bigint;
 -- ALTER TABLE person ALTER COLUMN   gender_concept_id TYPE bigint;


### PR DESCRIPTION
An issue with the ETL as it is that the the table name "omop" is hardcoded in several locations and the environment variables $OMOP and $OMOP_SCHEMA are ignored, making it hard to run the ETL with a schema name other than "omop". 

I have modified the ETL files such that they refer to a postgres variable ":OMOP_SCHEMA" that must be passed to the ETL call, like so: psql "$MIMIC" --set=OMOP_SCHEMA="$OMOP_SCHEMA" -f "etl/etl.sql"

There are other files in the repo that should also be changed, but as of now I have only modified those that are necessary for the ETL.